### PR TITLE
installation of bson_ext for non-java rubies

### DIFF
--- a/em-mongo.gemspec
+++ b/em-mongo.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.files      = Dir['VERSION', 'lib/**/*']
   s.test_files = Dir['spec/integration/**/*']
+  s.extensions = 'ext/em-mongo/extconf.rb'
 
   s.rdoc_options  = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
@@ -24,7 +25,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'eventmachine', ['>= 0.12.10'] 
   s.add_dependency 'bson', ['>= 1.1.3'] 
-  s.add_dependency 'bson_ext'
 
   s.add_development_dependency 'bundler'
 

--- a/ext/em-mongo/extconf.rb
+++ b/ext/em-mongo/extconf.rb
@@ -1,0 +1,22 @@
+# Install bson_ext when not on jruby.
+unless RUBY_PLATFORM =~ /^java/i
+  require 'mkmf'
+  require 'rubygems'
+
+  puts %Q{Ruby engine: #{RUBY_ENGINE}}
+  puts %Q{The "bson_ext" gem will now be installed. This gem provides a C extension for better performance.}
+
+  Gem.install('bson_ext')
+end
+
+# Writes an empty Makefile to pass the native extensions build for
+# all rubies.
+File.open('Makefile', 'w') do |f|
+  f.puts "all:"
+  f.puts "\t@true"
+  f.puts "install:"
+  f.puts "\t@true"
+end
+
+# Exit successfully on any ruby.
+exit 0


### PR DESCRIPTION
Applying this change allows fl00r/em-mongo to work on JRuby.

The bson_ext provides C extensions which are not supported for java
platforms (i.e. JRuby). This change will install bson_ext only if
the gem is installed on a non-java ruby.

This implemented using an extconf.rb file.